### PR TITLE
Updated to add ability to get dimensions of the terminal window

### DIFF
--- a/rlutil.h
+++ b/rlutil.h
@@ -478,6 +478,42 @@ void inline msleep(unsigned int ms) {
 #endif
 }
 
+/// Function: trows
+/// Get the number of rows in the terminal
+int trows() {
+#ifdef WIN32
+	return crows();
+#else
+#ifdef TIOCGSIZE
+	struct ttysize ts;
+	ioctl(STDIN_FILENO, TIOCGSIZE, &ts);
+	return ts.ts_lines;
+#elif defined(TIOCGWINSZ)
+	struct winsize ts;
+	ioctl(STDIN_FILENO, TIOCGWINSZ, &ts);
+	return ts.ws_row;
+#endif // TIOCGSIZE
+#endif //WIN32
+}
+	
+/// Function: tcols
+/// Get the number of columns in the terminal
+int tcols() {
+#ifdef WIN32
+	return ccols();
+#else
+#ifdef TIOCGSIZE
+	struct ttysize ts;
+	ioctl(STDIN_FILENO, TIOCGSIZE, &ts);
+	return ts.ts_cols;
+#elif defined(TIOCGWINSZ)
+	struct winsize ts;
+	ioctl(STDIN_FILENO, TIOCGWINSZ, &ts);
+	return ts.ws_col;
+#endif // TIOCGSIZE 
+#endif // WIN32 
+}	
+	
 // TODO: Allow optional message for anykey()?
 
 /// Function: anykey

--- a/test.cpp
+++ b/test.cpp
@@ -130,6 +130,13 @@ int main() {
 	}
 	waitkey;
 
+	rlutil::cls();
+	std::cout << "Test 10: Terminal Dimensions" << std::endl;
+	std::cout << "You should see the size in character rows and columns of your terminal window." << std::endl;
+	std::cout << rlutil::trows() << " Rows" << std::endl;
+	std::cout << rlutil::tcols() << " Columns" << std::endl;
+	waitkey;
+	
 	std::cout << "All tests done. Bye!" << std::endl;
 	return 0;
 }


### PR DESCRIPTION
I tested this with gcc and g++ however was not able to test on a windows machine as I do not have windows. I will be happy to make changes if something is broken.
