### PR TITLE
Add an (optional) argument to anykey()

### DIFF
--- a/example.c
+++ b/example.c
@@ -47,7 +47,7 @@ void draw() {
 	setColor(MAGENTA);
 	printf("Moves: %d\n", moves);
 	setColor(GREEN);
-	printf("Level: %d\n", level); 
+	printf("Level: %d\n", level);
 	locate(1, 1);
 	int i, j;
 	for (j = 0; j < MAPSIZE; j++) {
@@ -75,8 +75,7 @@ int main() {
 	setColor(2);
 	printf("Welcome! Use WASD to move.\n");
 	setColor(6);
-	printf("Hit any key to start.\n");
-	anykey();
+	anykey("Hit any key to start.\n");
 	draw();
 	while (1) {
 		// Input

--- a/rlutil.h
+++ b/rlutil.h
@@ -541,13 +541,28 @@ RLUTIL_INLINE int tcols(void) {
 	return -1;
 #endif // TIOCGSIZE
 #endif // _WIN32
-}	
-	
-// TODO: Allow optional message for anykey()?
+}
 
 /// Function: anykey
 /// Waits until a key is pressed.
-RLUTIL_INLINE void anykey(void) {
+/// In C++, it either takes no arguments
+/// or a template-type-argument-deduced
+/// argument.
+/// In C, it takes a const char* representing
+/// the message to be displayed, or NULL
+/// for no message.
+#ifdef __cplusplus
+RLUTIL_INLINE void anykey() {
+	getch();
+}
+
+template <class T> void anykey(const T& msg) {
+	RLUTIL_PRINT(msg);
+#else
+RLUTIL_INLINE void anykey(const char* msg) { // cannot use `const RLUTIL_STRING_T` here, because it yields char * const
+	if(msg)
+		RLUTIL_PRINT(msg);
+#endif // __cplusplus
 	getch();
 }
 


### PR DESCRIPTION
In C++, it either takes no arguments or a template-type-argument-deduced argument.
In C, it takes a `const char*` representing the message to be displayed, or NULL for no message.

Also updates the C example with the new syntax.