### PR TITLE
Fix missing void argument in functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 CFLAGS=-g -O2 -Wall -Wextra -Wstrict-prototypes
+CXXFLAGS=-g -O2 -Wall -Wextra
 
 all: test example-c
 
 test: rlutil.h test.cpp
-	$(CXX) $(CFLAGS) -o test test.cpp
+	$(CXX) $(CXXFLAGS) -o test test.cpp
 
 example-c: rlutil.h example.c
 	$(CC) $(CFLAGS) -o example-c example.c

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS=-g -O2 -Wall -Wextra
+CFLAGS=-g -O2 -Wall -Wextra -Wstrict-prototypes
 
 all: test example-c
 

--- a/rlutil.h
+++ b/rlutil.h
@@ -493,7 +493,7 @@ RLUTIL_INLINE void setBackgroundColor(int c) {
 ///
 /// See <Color Codes>
 /// See <resetColor>
-RLUTIL_INLINE int saveDefaultColor() {
+RLUTIL_INLINE int saveDefaultColor(void) {
 #if defined(_WIN32) && !defined(RLUTIL_USE_ANSI)
 	static char initialized = 0; // bool
 	static WORD attributes;
@@ -517,7 +517,7 @@ RLUTIL_INLINE int saveDefaultColor() {
 /// See <Color Codes>
 /// See <setColor>
 /// See <saveDefaultColor>
-RLUTIL_INLINE void resetColor() {
+RLUTIL_INLINE void resetColor(void) {
 #if defined(_WIN32) && !defined(RLUTIL_USE_ANSI)
 	SetConsoleTextAttribute(GetStdHandle(STD_OUTPUT_HANDLE), (WORD)saveDefaultColor());
 #else


### PR DESCRIPTION
Proper C functions with no parameters should be of the form `void foo(void)`; this also works for C++.

Without it, GCC will warn about strict prototypes.

See http://stackoverflow.com/q/51032/2038264