### PR TITLE
replace usleep() with nanosleep() in msleep(), add a missing default case in getkey()

### DIFF
--- a/rlutil.h
+++ b/rlutil.h
@@ -1,5 +1,4 @@
-/* #pragma once */
-/* ^ Not entirely portable ^ */
+#pragma once
 /**
  * File: rlutil.h
  *

--- a/rlutil.h
+++ b/rlutil.h
@@ -1,4 +1,5 @@
-#pragma once
+/* #pragma once */
+/* ^ Not entirely portable ^ */
 /**
  * File: rlutil.h
  *
@@ -49,6 +50,7 @@
 	}
 #else
 	#include <stdio.h> // for getch() / printf()
+
 	#include <string.h> // for strlen()
 	RLUTIL_INLINE void locate(int x, int y); // Forward declare for C to avoid warnings
 #endif // __cplusplus
@@ -61,7 +63,8 @@
 	#define kbhit _kbhit
 #else
 	#include <termios.h> // for getch() and kbhit()
-	#include <unistd.h> // for getch(), kbhit() and (u)sleep()
+	#include <unistd.h> // for getch() and kbhit()
+        #include <time.h>   // for nanosleep()
 	#include <sys/ioctl.h> // for getkey()
 	#include <sys/types.h> // for kbhit()
 	#include <sys/time.h> // for kbhit()
@@ -392,6 +395,7 @@ RLUTIL_INLINE int getkey(void) {
 					case 'B': return KEY_DOWN;
 					case 'C': return KEY_RIGHT;
 					case 'D': return KEY_LEFT;
+                                        default: return -1;
 				}
 			} else return KEY_ESCAPE;
 		}
@@ -637,9 +641,14 @@ RLUTIL_INLINE void msleep(unsigned int ms) {
 #ifdef _WIN32
 	Sleep(ms);
 #else
-	// usleep argument must be under 1 000 000
-	if (ms > 1000) sleep(ms/1000000);
-	usleep((ms % 1000000) * 1000);
+        struct timespec ts;
+
+	ts.tv_sec = ms / 1000;
+        ts.tv_nsec = (ms % 1000) * 1000000L;
+        
+	if(nanosleep(&ts, NULL) < 0) {
+                perror("sleep failed");
+        }
 #endif
 }
 


### PR DESCRIPTION
`usleep()` has been removed in POSIX 2008, C code that includes `rlutil.h` will not compile if `_POSIX_C_SOURCE` is set to `200809L` or greater. 

`nanosleep()` from `time.h` is a suggested alternative and compiles successfully whether the POSIX standard is set or not.

Also, a default case has been missing in `getkey()` in the switch case for processing ASCII escapes.
Not having a default case also causes C code to not compile when universally appropriate warning flags are turned on with gcc.

I set the default case to return -1, but there might be a better alternative (if maybe a #define to -1 somewhere for code readability).