### PR TITLE
Code did not work with Windows compiler that had UNICODE support. Qui…

### DIFF
--- a/rlutil.h
+++ b/rlutil.h
@@ -585,7 +585,16 @@ RLUTIL_INLINE void setString(RLUTIL_STRING_T str) {
 	CONSOLE_SCREEN_BUFFER_INFO csbi;
 
 	GetConsoleScreenBufferInfo(hConsoleOutput, &csbi);
-	WriteConsoleOutputCharacter(hConsoleOutput, str, len, csbi.dwCursorPosition, &numberOfCharsWritten);
+	
+	#if defined(UNICODE) || defined(_UNICODE)
+		int size = MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, str, -1, NULL, 0);
+		TCHAR* tstr = (TCHAR*)malloc(size);
+		MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, str, -1, tstr, size);
+		WriteConsoleOutputCharacter(hConsoleOutput, tstr, len, csbi.dwCursorPosition, &numberOfCharsWritten);
+		free(tstr);
+	#else
+		WriteConsoleOutputCharacter(hConsoleOutput, str, len, csbi.dwCursorPosition, &numberOfCharsWritten);
+	#endif
 #else // _WIN32 || USE_ANSI
 	RLUTIL_PRINT(str);
 	#ifdef __cplusplus


### PR DESCRIPTION
`WriteConsoleOutputCharacter` call did not compile on my version of MSVC. I think that's because when Unicode support is turned on, the call expects second argument to be of type `wchar_t`, not `char`. Added a quick conversion routine to make it compile - but maybe more changes are needed for everything to play well with `wchar_t`.